### PR TITLE
initial commit of template builder sync

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -1,0 +1,87 @@
+on:
+  workflow_call:
+
+#env:
+#  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+#  GH_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+jobs:
+  sync-diffs-with-template-builder:
+    name: "Track updated files"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
+    steps:
+      - name: 'get repo'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v29
+        with:
+          files: |
+            .platform.app.yaml
+            .platform/routes.yaml
+            .platform/services.yaml
+            .platform/applications.yaml
+
+      - name: 'Set up Github token'
+        id: setup-gh-token
+        shell: bash
+        run: echo "GITHUB_TOKEN=${{ secrets.TEMPLATES_GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: "Clone template-builder"
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+          repository: platformsh/template-builder
+          path: template-builder
+
+      - name: 'set git config'
+        shell: bash
+        run: |
+          git config --global user.email "devrel@internal.platform.sh"
+          git config --global user.name "platformsh-devrel"
+
+      - name: Test above
+        run: |
+          if [ "${{ steps.changed-files.outputs.all_changed_files }}" == "" ];then
+              echo "No relevant files modified. All is well."
+          else
+
+              # Get current template name.
+              arrIN=(${GITHUB_REPOSITORY//\// })
+              TEMPLATE=${arrIN[1]}
+              SYNC_BRANCH=sync-$TEMPLATE
+
+              # Clone template-builder, and create a new branch that matches changes in template repo.
+              # echo "Cloning template-builder"
+              # git clone git@github.com:platformsh/template-builder.git
+              cd template-builder
+              git checkout -b $SYNC_BRANCH
+
+              # Copy and stage the changed files
+              echo "Syncing revisions into template-builder"
+              NL=$'\n'
+              msg="Synching $GITHUB_REPOSITORY ($GITHUB_SHA).${NL}"
+
+              for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+                echo "Syncing $file"
+                cp ../$file templates/$TEMPLATE/files/$file
+                git add templates/$TEMPLATE/files/$file
+                msg="${msg} Updates templates/${TEMPLATE}/files/${file}.${NL}"
+              done
+
+              # Commit and push to template-builder.
+              echo "Commit and push"
+              # git add .
+              git commit -m "${msg}"
+              git status
+              git push origin ${SYNC_BRANCH}
+
+              # Create the corresponding PR.
+              gh pr create \
+                --head ${SYNC_BRANCH} \
+                --title "Sync: matching ${GITHUB_REPOSITORY}" \
+                --body "Syncing updates made in the latest [pull request](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
+          fi


### PR DESCRIPTION
initial commit of template builder sync RW to automate the creation of PRs back to the template builder repo when psh configuration files are updated in a template repository