### PR TITLE
Enhance/2 remove names

### DIFF
--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -1,19 +1,45 @@
 on:
   workflow_call:
-
+    inputs:
+      # CallingWorkflow-jobid
+      cw-jobid:
+        required: false
+        type: string
+        default: 'TestPrEnv-CW'
+        description: 'The name of the job id in the calling workflow. Defaults to `TestPrEnv-CW`'
+      status-checks:
+        required: false
+        type: string
+        default: ''
+        description: "Comma seperated list of status checks that must pass for the PR to be accepted. Defaults to `platformsh,TestPrEnv-CW / TestPrEnvironment`"
+env:
+  # This is the job id at line 5 from testprenvironment.yaml. If that job id changes, you'll need to update this value
+  RW_PRENV_JOBID: 'TestPrEnvironment'
 jobs:
   create-auto-pr:
     name: "Creates an auto merging PR when the branch is updated"
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
+      - name: 'Prep Default Status Checks'
+        id: prep_default_sc
+        run: |
+          echo "defaultStatusCheck=${{ inputs.cw-jobid }} / ${{ env.RW_PRENV_JOBID }}" >> $GITHUB_OUTPUT
+      - name: 'Prep Status Checks'
+        id: prep_status_check
+        run: |
+          # get the value the user might have passed in to override ALL defaults
+          userStatusCheck=${{ inputs.status-checks }}
+          # now get our "default" that takes any updated calling workflow job id and prepends it the the testprenvironment job id
+          defaultStatusCheck=${{ steps.prep_default_sc.outputs.defaultStatusCheck }}
+          # if they actually gave us something, use it; otherwise use our default
+          echo "statusCheck=${userStatusCheck:-${defaultStatusCheck}" >> $GITHUB_OUTPUT
       - name: 'Prep the repo for autoPR'
         id: prepautopr
         uses: platformsh/gha-prep-for-autopr@main
         with:
           github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-          #status-checks: 'call-reusable-testpr / TestPrEnvironment'
-          status-checks: 'TestPREnvironment-RW / TestPrEnvironment'
+          status-checks: ${{ steps.prep_status_check.outputs.statusCheck }}
 
       - name: 'Create & merge PR'
         id: create-merge-pr

--- a/.github/workflows/testprenvironment.yaml
+++ b/.github/workflows/testprenvironment.yaml
@@ -2,8 +2,9 @@ on:
   workflow_call:
 
 jobs:
-  test-pr-env:
-    name: TestPrEnvironment
+  # !!!! WARNING !!!!
+  # If for some reason this job id needs to change, you'll need to update the value for env:RW_PRENV_JOBID in autopr.yaml
+  TestPrEnvironment:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' && github.event.pull_request.draft == false }}
     steps:


### PR DESCRIPTION
Closes #2 

* Adds input `cw-jobid` (CallingWorkflow-JobID) in [autopr.yaml](./.github/workflows/autopr.yaml) to allow for overriding the calling workflow jobid that we have set in a new template's testprenvironment.yaml workflow file
* Adds input `status-check` in [autopr.yaml](./.github/workflows/autopr.yaml) for overriding the default status check altogether
* Adds env var in [autopr.yaml](./.github/workflows/autopr.yaml) for the job id that is used in testprenvironment.yaml when calling the GH action
* Adds steps for parsing the above inputs and prepping then for sending the status-check input to the platformsh/gha-prep-for-autopr GH Action
* Renames job id from test-pr-renv to TestPrEnvironment in [testprenvironment.yaml](./.github/workflows/testprenvironment.yaml)
* Adds internal documentation reflecting the need to update the env var in the autopr.yaml if the jobid changes