### PR TITLE
Update tb-sync.yaml

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -19,7 +19,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v29
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           files: |
             .platform.app.yaml
             .platform/routes.yaml


### PR DESCRIPTION
updates `fetch-depth` for changed-files action from 2 to 0

action is still complaining that there isn't enough commit history to determine changes.

```
  Error: Similar commit hashes detected: previous sha: 277b9be8924c18749f3806552056776f3b01cb58 is equivalent to the current sha: 277b9be8924c18749f3806552056776f3b01cb58
  Error: You seem to be missing 'fetch-depth: 0' or 'fetch-depth: 2'. See https://github.com/tj-actions/changed-files#usage
```