### PR TITLE
Update tb-sync.yaml

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -19,7 +19,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v35
         with:
-          fetch-depth: 0
+          fetch_depth: 0
           files: |
             .platform.app.yaml
             .platform/routes.yaml


### PR DESCRIPTION
input name changed from `fetch-depth` to `fetch_depth` between v29 and v35 of the changed-files action