### PR TITLE
Point to template updates project

### DIFF
--- a/.github/workflows/project-issues.yaml
+++ b/.github/workflows/project-issues.yaml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.1
         with:
-          project-url: https://github.com/orgs/platformsh/projects/9
+          project-url: https://github.com/orgs/platformsh/projects/10
           github-token: ${{ secrets.DEVREL_TOKEN }}


### PR DESCRIPTION
https://github.com/orgs/platformsh/projects/10 (template updates) rather than the main template-builder project, at least for now