### PR TITLE
[Enhancement] TB Sync changes

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -59,20 +59,20 @@ jobs:
         id: get-pr-number
         shell: bash
         run: |
-          # we need the pull request number that created the push that triggered this event.  
+          # we need the pull request number that created the push that triggered this event.
           prNumber=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" | jq -r '.[] | .number')
-          
+
           if [[ -n "$prNumber" ]]; then
             continueJobs="yes"
-            echo "PRNUMBER=${prNumber}" >> $GITHUB_ENV  
+            echo "PRNUMBER=${prNumber}" >> $GITHUB_ENV
           else
             continueJobs="no"
           fi
-          
+
           echo "CONTINUEJOBS=${continueJobs}" >> "$GITHUB_OUTPUT"
 
       - name: Determine if push was from Template-Builder
-        if: steps.get-pr-number.outputs.CONTINUEJOBS == "yes"
+        if: steps.get-pr-number.outputs.CONTINUEJOBS == 'yes'
         id: determine-if-pr-from-tb
         shell: bash
         run: |
@@ -83,26 +83,51 @@ jobs:
           else
             continueJobs="yes"
           fi
-          
+
           echo "CONTINUEJOBS=${continueJobs}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine Template Name
+        id: determine-template-name
+        shell: bash
+        if: steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes'
+        run: |
+          # Get current template name.
+          arrIN=(${GITHUB_REPOSITORY//\// })
+          TEMPLATE=${arrIN[1]}
+          # we need this in a later step as well
+          echo "TEMPLATENAME=${TEMPLATE}" >> $GITHUB_ENV
+
+      - name: Prep issue message
+        if: >-
+          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' &&
+          (
+            contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+          )
+        shell: bash
+        run: |
+          touch issue-message.txt
+          NL=$'\n'
+          # we want the link back to the PR that changed the package management file
+          prURL="https://github.com/$GITHUB_REPOSITORY/pulls/${{ env.PRNUMBER }}"
+          issueBody="One or more package management files were changed in [pull request ${{ env.PRNUMBER }}]"
+          issueBody="${issueBody}(${prURL}) for template ${{ env.TEMPLATENAME }}.${NL}${NL}"
+
+          echo "${issueBody}" >> issue-message.txt
 
       - name: "Sync updated psh configuration files"
         shell: bash
         id: build-tb-pr
-        if: steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == "yes"
+        if: steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes'
         run: |
           if [ "${{ steps.changed-files.outputs.all_changed_files }}" == "" ];then
               echo "::notice::No relevant files modified. All is well."
           else
-              # Get current template name.
-              arrIN=(${GITHUB_REPOSITORY//\// })
-              TEMPLATE=${arrIN[1]}
-              # we need this in a later step as well
-              echo "TEMPLATENAME=${TEMPLATE}" >> $GITHUB_ENV
-              SYNC_BRANCH=sync-$TEMPLATE
+              addLabel="no"
+              SYNC_BRANCH=sync-${{ env.TEMPLATENAME }}
 
               # Clone template-builder, and create a new branch that matches changes in template repo.
-              cd template-builder
+              cd ${{ env.TBLOCALPATH }}
               #let's make sure we have all the info from origin
               git fetch origin
               #now let's see if the branch we need already exists

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
           repository: ${{ env.TEMPLATEBUILDER }}
-          path: ${{ env.TEMPLATEBUILDER }}
+          path: template-builder
 
       - name: 'set git config'
         shell: bash

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -91,30 +91,44 @@ jobs:
               # Get current template name.
               arrIN=(${GITHUB_REPOSITORY//\// })
               TEMPLATE=${arrIN[1]}
+              # we need this in a later step as well
+              echo "TEMPLATENAME=${TEMPLATE}" >> $GITHUB_ENV
               SYNC_BRANCH=sync-$TEMPLATE
 
               # Clone template-builder, and create a new branch that matches changes in template repo.
               cd template-builder
               #let's make sure we have all the info from origin
               git fetch origin
-              #now let's see if the banch we need already exists
+              #now let's see if the branch we need already exists
               remoteBranch=$(git ls-remote --heads origin "${SYNC_BRANCH}")
               # if the remote branch already exists, then we need to check it out from origin. otherwise, create a new
               # local branch that we'll push up later
               # @todo is there a way to retrieve the remote name instead of assuming it is 'origin'?
               git checkout -b "${SYNC_BRANCH}" "${remoteBranch+origin/${SYNC_BRANCH}}"
 
+              # go ahead and get the data on the files that were changed in the commit
+              prFileData=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${{ env.PRNUMBER }}/files")
+              
               # Copy and stage the changed files
               echo "Syncing revisions into template-builder"
               NL=$'\n'
               msg="Synching $GITHUB_REPOSITORY ($GITHUB_SHA).${NL}"
-
+              issueMsg=""
               for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-                echo "Syncing $file"
-                cp ../$file templates/$TEMPLATE/files/$file
-                git add templates/$TEMPLATE/files/$file
-                msg="${msg} Updates templates/${TEMPLATE}/files/${file}.${NL}"
-                echo "::notice::The configuration file ${file} has been changed and will be added to a PR for Template Builder."
+                # @todo this is brittle, especially if we increase the number of files we dont want to commit
+                # is there a way to filter these two files out of the list?
+                if [[ "${file}" != "composer.json" ]] && [[ "${file}" != "packages.json" ]]; then
+                  echo "Syncing $file"
+                  cp ../$file templates/$TEMPLATE/files/$file
+                  git add templates/$TEMPLATE/files/$file
+                  msg="${msg} Updates templates/${TEMPLATE}/files/${file}.${NL}"
+                  echo "::notice::The configuration file ${file} has been changed and will be added to a PR for Template Builder."
+                else
+                  # let's go ahead and build up our issue message
+                  issueMsg="${issueMsg}The package management file ${file} was changed. The following is the patch:${NL}```${NL}"
+                  filePatch=$(jq --arg filename "${file}" -r '.[] | select(.filename==$filename) | .patch' <<< ${prFileData})
+                  issueMsg="${issueMsg}${filePatch}${NL}```${NL}"
+                fi
               done
 
               # Commit and push to template-builder.

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -191,7 +191,6 @@ jobs:
                 prBody="Syncing updates for template ${{ env.TEMPLATEBUILDER }} made in the latest [pull request](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
 
                 # do we already have an open PR for this branch?
-                # gh pr list -H sync-wordpress-composer --json number | jq -r '.[] | .number'
                 tbPRData=$(gh pr list -H "${SYNC_BRANCH}" --json number,url -R ${{ env.TEMPLATEBUILDER }})
 
                 if [[ "${tbPRData}" == "[]" ]]; then

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -35,7 +35,7 @@ jobs:
             .platform/services.yaml
             .platform/applications.yaml
             composer.json
-            packages.json
+            package.json
 
       - name: 'Set up Github token'
         id: setup-gh-token

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -49,7 +49,41 @@ jobs:
           git config --global user.email "devrel@internal.platform.sh"
           git config --global user.name "platformsh-devrel"
 
+      - name: Get Pull Request Number
+        id: get-pr-number
+        shell: bash
+        run: |
+          # we need the pull request number that created the push that triggered this event.  
+          prNumber=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" | jq -r '.[] | .number')
+          
+          if [[ -n "$prNumber" ]]; then
+            continueJobs="yes"
+            echo "PRNUMBER=${prNumber}" >> $GITHUB_ENV  
+          else
+            continueJobs="no"
+          fi
+          
+          echo "CONTINUEJOBS=${continueJobs}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine if push was from Template-Builder
+        if: steps.get-pr-number.outputs.CONTINUEJOBS == "yes"
+        id: determine-if-pr-from-tb
+        shell: bash
+        run: |
+          # if the push was from template builder, then we dont want to create a PR or issue back to template builder
+          prBranch=$(gh pr view ${{ env.PRNUMBER }} --json headRefName | jq -r '.headRefName')
+          if [[ "${{ env.TBUPDATEBRANCH }}" == "${prBranch}" ]]; then
+            continueJobs="no"
+          else
+            continueJobs="yes"
+          fi
+          
+          echo "CONTINUEJOBS=${continueJobs}" >> "$GITHUB_OUTPUT"
+
       - name: "Sync updated psh configuration files"
+        shell: bash
+        id: build-tb-pr
+        if: steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == "yes"
         run: |
           if [ "${{ steps.changed-files.outputs.all_changed_files }}" == "" ];then
               echo "::notice::No relevant files modified. All is well."

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -102,7 +102,7 @@ jobs:
           steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' &&
           (
             contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
-            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+            contains(steps.changed-files.outputs.all_changed_files, 'package.json')
           )
         shell: bash
         run: |
@@ -154,7 +154,7 @@ jobs:
               for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
                 # @todo this is brittle, especially if we increase the number of files we dont want to commit
                 # is there a way to filter these two files out of the list?
-                if [[ "${file}" != "composer.json" ]] && [[ "${file}" != "packages.json" ]]; then
+                if [[ "${file}" != "composer.json" ]] && [[ "${file}" != "package.json" ]]; then
                   echo "Syncing $file"
                   cp ../$file templates/${{ env.TEMPLATENAME }}/files/$file
                   git add templates/${{ env.TEMPLATENAME }}/files/$file
@@ -231,7 +231,7 @@ jobs:
           steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' &&
           (
             contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
-            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+            contains(steps.changed-files.outputs.all_changed_files, 'package.json')
           )
         run: |
           NL=$'\n'
@@ -279,7 +279,7 @@ jobs:
           steps.create-issue.outputs.addlabel == 'yes' &&
           (
             contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
-            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+            contains(steps.changed-files.outputs.all_changed_files, 'package.json')
           )
         uses: platformsh/gha-add-label@main
         with:

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -2,8 +2,10 @@ on:
   workflow_call:
 
 env:
-  TEMPLATEBUILDER: platformsh/template-builder
+  TBOWNER: platformsh
+  TBREPO: template-builder
   TBUPDATEBRANCH: updatesLocal
+  TBLOCALPATH: template-builder
 
 jobs:
   sync-diffs-with-template-builder:
@@ -11,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
     steps:
+      - name: Set TemplateBuilder
+        shell: bash
+        run: |
+          echo "TEMPLATEBUILDER=${{ env.TBOWNER }}/${{ env.TBREPO }}" >> $GITHUB_ENV
       - name: 'get repo'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -152,4 +152,40 @@ jobs:
               else
                 echo "::notice::Created a PR in template builder with the latest changes: ${prURL}."
               fi
+          
+              echo "ISSUEMSG=${issueMsg}" >> $GITHUB_OUTPUT
+          fi
+
+
+      - name: Create issue if package management files were changed
+        shell: bash
+        if: >-
+          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == "yes" &&
+          (
+            contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+          )
+        run: |
+          NL=$'\n'          
+          # we want the link back to the PR that changed the package management file
+          prURL="https://github.com/$GITHUB_REPOSITORY/pulls/${{ env.PRNUMBER }}"
+
+          #now we need to set up the title and body of the issue and post to template builder
+          issueTitle="Package Management changes made to template ${{ env.TEMPLATENAME }}"
+          
+          issueBody="One or more package management files were changed in [pull request ${{ env.PRNUMBER }}]"
+          issueBody="${issueBody}(${prURL}) for template ${{ env.TEMPLATENAME }}.${NL}${NL}" 
+          issueBody="${issueBody}${{ steps.build-tb-pr.outputs.ISSUEMSG }}"
+          issueBody="${NL}${NL}Link to all changed files in the PR: [${prURL/files}](${prURL}/files)"
+          
+          # now create the issue
+          issueNumber=$(gh issue create -t "${issueTitle}" -R "${{ en.TEMPLATEBUILDER }} -b "${issueBody}")
+          
+          if [ -z "${issueNumber}" ]; then
+            echo "::warning::Creating an issue in template builder for changes to package management files failed!"
+            echo "::debug::Return from issue create command was:"
+            prCommand="pr create --head \"${SYNC_BRANCH}\" --title \"${prTitle}\" --body \"${prBody}\""
+            echo "::debug::${issueNumber}"
+          else
+            echo "::notice::Created an issue in template builder: ${issueNumber}."
           fi

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
           repository: platformsh/template-builder
-          path: template-builder
+          path: ${{ env.TEMPLATEBUILDER }}
 
       - name: 'set git config'
         shell: bash

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-          repository: platformsh/template-builder
+          repository: ${{ env.TEMPLATEBUILDER }}
           path: ${{ env.TEMPLATEBUILDER }}
 
       - name: 'set git config'

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -135,88 +135,157 @@ jobs:
               # if the remote branch already exists, then we need to check it out from origin. otherwise, create a new
               # local branch that we'll push up later
               # @todo is there a way to retrieve the remote name instead of assuming it is 'origin'?
-              git checkout -b "${SYNC_BRANCH}" "${remoteBranch+origin/${SYNC_BRANCH}}"
+              #git checkout -b "${SYNC_BRANCH}""${remoteBranch:+ origin/${SYNC_BRANCH}}"
+              if [[ -z "${remoteBranch}" ]]; then
+                git checkout -b "${SYNC_BRANCH}"
+              else
+                git checkout -b "${SYNC_BRANCH}" "origin/${SYNC_BRANCH}"
+              fi
 
               # go ahead and get the data on the files that were changed in the commit
               prFileData=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${{ env.PRNUMBER }}/files")
-              
+              #pr url structure
+              prURLpattern="https://github.com/%s/pull/%s/files#diff-%s"
               # Copy and stage the changed files
               echo "Syncing revisions into template-builder"
               NL=$'\n'
               msg="Synching $GITHUB_REPOSITORY ($GITHUB_SHA).${NL}"
-              issueMsg=""
+
               for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
                 # @todo this is brittle, especially if we increase the number of files we dont want to commit
                 # is there a way to filter these two files out of the list?
                 if [[ "${file}" != "composer.json" ]] && [[ "${file}" != "packages.json" ]]; then
                   echo "Syncing $file"
-                  cp ../$file templates/$TEMPLATE/files/$file
-                  git add templates/$TEMPLATE/files/$file
-                  msg="${msg} Updates templates/${TEMPLATE}/files/${file}.${NL}"
+                  cp ../$file templates/${{ env.TEMPLATENAME }}/files/$file
+                  git add templates/${{ env.TEMPLATENAME }}/files/$file
+                  msg="${msg} Updates templates/${{ env.TEMPLATENAME }}/files/${file}.${NL}"
                   echo "::notice::The configuration file ${file} has been changed and will be added to a PR for Template Builder."
                 else
                   # let's go ahead and build up our issue message
-                  issueMsg="${issueMsg}The package management file ${file} was changed. The following is the patch:${NL}```${NL}"
-                  filePatch=$(jq --arg filename "${file}" -r '.[] | select(.filename==$filename) | .patch' <<< ${prFileData})
-                  issueMsg="${issueMsg}${filePatch}${NL}```${NL}"
+                  echo "::notice::Saving an issue message for ${file}"
+                  {
+                    echo "The package management file ${file} was changed. The following is the patch:";
+                    echo "\`\`\`";
+                    echo "$(jq --arg filename "${file}" -r '.[] | select(.filename==$filename) | .patch' <<< ${prFileData})";
+                    echo "\`\`\`";
+                    echo "";
+                    echo "Link to the diff above: ";
+                    fileDiffVal=$(echo -n "${file}" | shasum -a 256 | cut -d ' ' -f1);
+                    echo $(printf "${prURLpattern}" "${GITHUB_REPOSITORY}" "${{ env.PRNUMBER }}" "${fileDiffVal}");
+                    echo "";
+                    echo "";
+                    } >> ../issue-message.txt
                 fi
               done
 
-              # Commit and push to template-builder.
-              echo "Commit and push"
-              # git add .
-              git commit -m "${msg}"
-              git status
-              git push origin ${SYNC_BRANCH}
+              # do we have anything to actually commit?
+              if [[ $(git diff --name-only --cached) ]]; then
+                # Commit and push to template-builder.
+                echo "Commit and push"
+                # git add .
+                git commit -m "${msg}"
+                git status
+                git push origin ${SYNC_BRANCH}
 
-              prTitle="Sync: matching ${GITHUB_REPOSITORY}"
-              prBody="Syncing updates for template ${TEMPLATE} made in the latest [pull request](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
+                prTitle="Sync: matching ${GITHUB_REPOSITORY}"
+                prBody="Syncing updates for template ${{ env.TEMPLATEBUILDER }} made in the latest [pull request](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
 
-              # Create the corresponding PR.
-              prURL=$(gh pr create --head ${SYNC_BRANCH} --title "${prTitle}" --body "${prBody}")
+                # do we already have an open PR for this branch?
+                # gh pr list -H sync-wordpress-composer --json number | jq -r '.[] | .number'
+                tbPRData=$(gh pr list -H "${SYNC_BRANCH}" --json number,url -R ${{ env.TEMPLATEBUILDER }})
 
-              if [ -z "${prURL}" ]; then
-                echo "::warning::Creating a PR in template builder for the latest changes failed."
-                echo "::debug::Command issued was:"
-                prCommand="pr create --head \"${SYNC_BRANCH}\" --title \"${prTitle}\" --body \"${prBody}\""
-                echo "::debug::${prCommand}"
-              else
-                echo "::notice::Created a PR in template builder with the latest changes: ${prURL}."
+                if [[ "${tbPRData}" == "[]" ]]; then
+                  # Create the corresponding PR.
+                  prURL=$(gh pr create --head ${SYNC_BRANCH} --title "${prTitle}" --body "${prBody}")
+
+                  if [ -z "${prURL}" ]; then
+                    echo "::warning::Creating a PR in template builder for the latest changes failed."
+                    echo "::debug::Command issued was:"
+                    prCommand="pr create --head \"${SYNC_BRANCH}\" --title \"${prTitle}\" --body \"${prBody}\""
+                    echo "::debug::${prCommand}"
+                  else
+                    echo "::notice::Created a PR in template builder with the latest changes: ${prURL}"
+                    addLabel="yes"
+                    echo "identifier=${prURL}" >> $GITHUB_OUTPUT
+                  fi
+                else
+                  #this means we already have an open PR
+                  echo "::notice::There is already an open pull request for ${SYNC_BRANCH} on ${{ env.TEMPLATEBUILDER }}."
+                  tbPR=$(jq -r '.[] | .number' <<< $tbPRData)
+                  tbPRUrl=$(jq -r '.[] | .url' <<< $tbPRData)
+                  echo "::notice::Please see pull request #${tbPR}: ${tbPRUrl}"
+                  # now let's add a comment
+                  gh pr comment "${tbPR}" -b "${prBody}" -R ${{ env.TEMPLATEBUILDER }}
+                fi
               fi
-          
-              echo "ISSUEMSG=${issueMsg}" >> $GITHUB_OUTPUT
+
+          echo "addlabel=${addLabel}" >> $GITHUB_OUTPUT
+
           fi
 
 
       - name: Create issue if package management files were changed
         shell: bash
+        id: create-issue
         if: >-
-          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == "yes" &&
+          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' &&
           (
             contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
             contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
           )
         run: |
-          NL=$'\n'          
-          # we want the link back to the PR that changed the package management file
-          prURL="https://github.com/$GITHUB_REPOSITORY/pulls/${{ env.PRNUMBER }}"
-
+          NL=$'\n'
+          addLabel="no"
           #now we need to set up the title and body of the issue and post to template builder
           issueTitle="Package Management changes made to template ${{ env.TEMPLATENAME }}"
-          
-          issueBody="One or more package management files were changed in [pull request ${{ env.PRNUMBER }}]"
-          issueBody="${issueBody}(${prURL}) for template ${{ env.TEMPLATENAME }}.${NL}${NL}" 
-          issueBody="${issueBody}${{ steps.build-tb-pr.outputs.ISSUEMSG }}"
-          issueBody="${NL}${NL}Link to all changed files in the PR: [${prURL/files}](${prURL}/files)"
-          
+
+          # this should never happen, but *just in case*...
+          if [[ ! -f "issue-message.txt" ]]; then
+            echo "Unable to retrieve patch information..." >> issue-message.txt
+          fi
+
           # now create the issue
-          issueNumber=$(gh issue create -t "${issueTitle}" -R "${{ en.TEMPLATEBUILDER }} -b "${issueBody}")
-          
+          issueNumber=$(gh issue create -t "${issueTitle}" -R "${{ env.TEMPLATEBUILDER }}" -F issue-message.txt)
+
           if [ -z "${issueNumber}" ]; then
             echo "::warning::Creating an issue in template builder for changes to package management files failed!"
             echo "::debug::Return from issue create command was:"
-            prCommand="pr create --head \"${SYNC_BRANCH}\" --title \"${prTitle}\" --body \"${prBody}\""
             echo "::debug::${issueNumber}"
           else
-            echo "::notice::Created an issue in template builder: ${issueNumber}."
+            echo "::notice::Created an issue in template builder: ${issueNumber}"
+            addLabel="yes"
+            echo "identifier=${issueNumber}" >> $GITHUB_OUTPUT
           fi
+
+          echo "addlabel=${addLabel}" >> $GITHUB_OUTPUT
+
+      - name: Add Label to PR
+        # We also need the pull request number...
+        if: >-
+          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' && steps.build-tb-pr.outputs.addlabel == 'yes'
+        uses: platformsh/gha-add-label@main
+        with:
+          issue-type: 'pull request'
+          identifier: ${{ steps.build-tb-pr.outputs.identifier }}
+          github-token: ${{ env.GITHUB_TOKEN }}
+          label: ${{ env.TEMPLATENAME }}
+          repo-owner: ${{ env.TBOWNER }}
+          repo-name: ${{ env.TBREPO }}
+
+      - name: Add Label to Issue
+        # We also need the issue number...
+        if: >-
+          steps.determine-if-pr-from-tb.outputs.CONTINUEJOBS == 'yes' &&
+          steps.create-issue.outputs.addlabel == 'yes' &&
+          (
+            contains(steps.changed-files.outputs.all_changed_files, 'composer.json') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'packages.json')
+          )
+        uses: platformsh/gha-add-label@main
+        with:
+          issue-type: 'issue'
+          identifier: ${{ steps.create-issue.outputs.identifier }}
+          github-token: ${{ env.GITHUB_TOKEN }}
+          label: ${{ env.TEMPLATENAME }}
+          repo-owner: ${{ env.TBOWNER }}
+          repo-name: ${{ env.TBREPO }}

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -28,6 +28,8 @@ jobs:
             .platform/routes.yaml
             .platform/services.yaml
             .platform/applications.yaml
+            composer.json
+            packages.json
 
       - name: 'Set up Github token'
         id: setup-gh-token

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
 
+env:
+  TEMPLATEBUILDER: platformsh/template-builder
+  TBUPDATEBRANCH: updatesLocal
+
 jobs:
   sync-diffs-with-template-builder:
     name: "Track psh configuration files"

--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
           repository: ${{ env.TEMPLATEBUILDER }}
-          path: template-builder
+          path: ${{ env.TBLOCALPATH }}
 
       - name: 'set git config'
         shell: bash


### PR DESCRIPTION
Makes the following changes:

- adds env var for template builder and the branch name template builder uses for template updates
- adds composer.json and packages.json to the list of files we're tracking in pushes to default_branch
- updates path input to template builder env var
- adds a job to determine pull request number based on pulls for the current sha
- adds a job to determine if the headRefName form that pull request is the name of the branch that is used by template builder. if it is, then we output a variable so we can skip running further jobs
- adds an if statement based on output of the previous step to the job where we create the PR against template builder
- refactors the pr creation job slightly:
  - stores the determined TEMPLATE name as an env var so we can reuse it again in a later step
  - retrieves the data on the files that were changed in the determined PR
  - skips including package management files in the files to be included in the pr
  - if package management files are present, we build up an issue message to be sent to the next job
  - saves the issue message from the PR building job as an output
- adds a new job for creating an issue in template builder
- uses the output message generated in the previous job to generate an issue on template builder indicating we need to examine the changed package management files