### PR TITLE
Update autopr.yaml

### DIFF
--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -40,3 +40,4 @@ jobs:
           github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
           trigger-source: 'auto push'
           default-branch: ${{ steps.prepautopr.outputs.default-branch }}
+          delete-branch-after-merge: 'yes'


### PR DESCRIPTION
Adds `delete-branch-after-merge: yes` to our call to the gha-create-autopr action

Previously we wanted to keep our update branch around so that we didn't have to recreate it every time. but after internal changes to how the github integration works, we now *need* the branch deleted after every successful merge. 