### PR TITLE
Adds support for an alt name for the update branch

### DIFF
--- a/.github/workflows/sourceops.yaml
+++ b/.github/workflows/sourceops.yaml
@@ -7,7 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
-      - name: 'Run source ops'
+      - name: 'Run source ops with alt branch'
+        if: ${{ vars.SOP_UPDATE_BRANCH != '' }}
+        id: run-source-op-alt-branch
+        uses: platformsh/gha-run-sourceops-update@main
+        with:
+          github_token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+          platformsh_token: ${{ secrets.TEMPLATES_CLI_TOKEN }}
+          update_branch_name: ${{ vars.SOP_UPDATE_BRANCH }}
+      - name: 'Run source ops with default branch'
+        if: ${{ vars.SOP_UPDATE_BRANCH == '' }}
         id: run-source-op
         uses: platformsh/gha-run-sourceops-update@main
         with:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ jobs:
 ## [sourceops.yaml](./.github/workflows/sourceops.yaml)
 ### Description
 Runs the Source Operations Toolkit
+### Inputs
+* To set the name of the branch the toolkit should target for the update, set a repository variable named `SOP_UPDATE_BRANCH`
+with the name of the branch.
 ### Uses
 * [platformsh/gha-run-sourceops-update](https://github.com/platformsh/gha-run-sourceops-update)
 ### Example:


### PR DESCRIPTION
In the sourceop.yaml reusable workflow, if the repo variable `SOP_UPDATE_BRANCH` is set, will pass that value to the source operation toolkit action so it will use the alt branch.

* adds support for creating a repo variable for an alternate name for the update branch
* Updates README to reflect the change