### PR TITLE
Update tb-sync.yaml

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -144,8 +144,10 @@ jobs:
           # Get current template name.
           arrIN=(${GITHUB_REPOSITORY//\// })
           TEMPLATE=${arrIN[1]}
+          # all template directories in template builder are lowercase; we have a few repositories that use camelCase
+          TEMPLATELOWER=$(echo "${TEMPLATE}" | tr '[A-Z]' '[a-z]')
           # we need this in a later step as well
-          echo "TEMPLATENAME=${TEMPLATE}" >> $GITHUB_ENV
+          echo "TEMPLATENAME=${TEMPLATELOWER}" >> $GITHUB_ENV
 
       - name: 'Prep issue message'
         if: >-


### PR DESCRIPTION
template directory names in template builder are all lower case. we have a handful of templates where the repository name uses mixed/camelCase. This change lowercases all template names before attempting to sync with template builder.